### PR TITLE
chore(deps): actualizar dependencias y documentación a v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es-ES/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-06-16
+
+### Changed
+- chore: Actualización de Spring Boot parent de 4.0.5 a 4.1.0.
+- chore: Actualización de Spring Cloud de 2025.1.0 a 2025.1.2.
+- chore: Actualización de springdoc-openapi-starter-webmvc-ui de 3.0.2 a 3.0.3.
+
+### Fuente
+- Basado en análisis de dependencias en `pom.xml` (`git diff HEAD`) y documentación.
+
 ## [0.4.0] - 2026-04-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 #### Lenguajes y Plataformas
 ![Java](https://img.shields.io/badge/Java-25-red?style=for-the-badge&logo=openjdk)
-![Spring Boot](https://img.shields.io/badge/Spring_Boot-4.0.5-green?style=for-the-badge&logo=spring-boot)
-![Spring Cloud](https://img.shields.io/badge/Spring_Cloud-2025.1.0-green?style=for-the-badge&logo=spring-cloud)
+![Spring Boot](https://img.shields.io/badge/Spring_Boot-4.1.0-green?style=for-the-badge&logo=spring-boot)
+![Spring Cloud](https://img.shields.io/badge/Spring_Cloud-2025.1.2-green?style=for-the-badge&logo=spring-cloud)
 
 #### Bases de Datos y Caché
 ![Caffeine](https://img.shields.io/badge/Caffeine_Cache-3.1.8-blue?style=for-the-badge)
@@ -21,7 +21,7 @@
 ![Lombok](https://img.shields.io/badge/Lombok-1.18.30-pink?style=for-the-badge)
 
 #### Documentación y API
-![OpenAPI](https://img.shields.io/badge/OpenAPI-3.0.2-blue?style=for-the-badge&logo=openapi)
+![OpenAPI](https://img.shields.io/badge/OpenAPI-3.0.3-blue?style=for-the-badge&logo=openapi)
 
 ### Estado del Pipeline
 [![UM.tesoreria.facturador-service CI](https://github.com/UM-services/UM.tesoreria.facturador-service/actions/workflows/maven.yml/badge.svg)](https://github.com/UM-services/UM.tesoreria.facturador-service/actions/workflows/maven.yml)
@@ -61,12 +61,12 @@ Microservicio de facturación electrónica para UM Tesorería. Se encarga de:
 
 ### Backend
 - Java 25
-- Spring Boot 4.0.5
-- Spring Cloud 2025.1.0
+- Spring Boot 4.1.0
+- Spring Cloud 2025.1.2
 - Maven 3.9+
 
 ### Herramientas y Utilidades
-- SpringDoc OpenAPI 3.0.2
+- SpringDoc OpenAPI 3.0.3
 - Spring AOP
 - Spring Validation
 - Feign Client para comunicación síncrona
@@ -82,13 +82,13 @@ Microservicio de facturación electrónica para UM Tesorería. Se encarga de:
 ## 🔄 API Endpoints
 
 ### Facturación
-- `GET /facturador/facturaPendientes`: Procesa facturas pendientes
-- `GET /facturador/facturaOne/{chequeraPagoId}`: Procesa una factura específica
-- `GET /facturador/sendOne/pago/{chequeraPagoId}`: Envía recibo por ID de chequera
-- `GET /facturador/sendOne/factura/{facturacionElectronicaId}`: Envía recibo por ID de factura
+- `GET /api/tesoreria/facturador/facturaPendientes`: Procesa facturas pendientes
+- `GET /api/tesoreria/facturador/facturaOne/{chequeraPagoId}`: Procesa una factura específica
+- `GET /api/tesoreria/facturador/sendOne/pago/{chequeraPagoId}`: Envía recibo por ID de chequera
+- `GET /api/tesoreria/facturador/sendOne/recibo/{facturacionElectronicaId}`: Envía recibo por ID de factura
 
 ### Características Principales
-- Integración con Eureka para registro de servicios
+- Integración con Consul para registro de servicios
 - Caché distribuido con Caffeine
 - Validación de datos con Spring Validation
 - Documentación automática con OpenAPI
@@ -139,81 +139,6 @@ El proyecto utiliza varias herramientas para mantener la calidad del código:
    - CI/CD automatizado
    - Generación de documentación
    - Análisis de calidad
-- JDK 21
-- Maven 3.9+
-- Docker y Docker Compose
-
-### Instalación Local
-
-```bash
-# Clonar repositorio
-git clone https://github.com/UM-services/UM.tesoreria.facturador-service.git
-
-# Instalar dependencias
-mvn clean install
-
-# Ejecutar
-mvn spring-boot:run
-```
-
-### Docker
-
-```bash
-# Construir imagen
-docker build -t um-tesoreria-facturador-service .
-
-# Ejecutar contenedor
-docker run -p 8080:8080 um-tesoreria-facturador-service
-```
-
-## 🔍 Monitoreo y Métricas
-
-El servicio expone endpoints de monitoreo a través de Spring Actuator:
-- `/actuator/health`: Estado de salud del servicio
-- `/actuator/metrics`: Métricas del sistema
-- `/actuator/info`: Información del servicio
-
-## 📝 Notas
-- El envío automático de facturas pendientes se ejecuta cada hora (cron: "0 0 * * * *")
-- Se procesan hasta 100 facturas pendientes por ejecución
-- La comunicación con tesoreria-sender-service es síncrona
-- Se recomienda revisar el CHANGELOG.md para conocer las últimas actualizaciones
 
 ## ✍️ Autor
 - Universidad de Mendoza - Ing. Daniel Quinteros
-
-### Características
-- Comunicación síncrona con tesoreria-sender-service
-- Procesamiento optimizado de facturas pendientes
-- Sistema de caché con Caffeine
-- Documentación automática con OpenAPI
-- Integración con Eureka para registro de servicios
-- Sistema de monitoreo con Spring Actuator
-- Validación de datos con Spring Validation
-
-### Notas
-- El servicio procesa facturas pendientes de forma programada
-- Se utiliza comunicación síncrona directa con tesoreria-sender-service
-- El sistema implementa un procesamiento optimizado por lotes
-- Se mantiene un sistema de logging detallado para seguimiento de operaciones
-- Se utiliza caché para optimizar el rendimiento
-- La documentación de la API está disponible a través de OpenAPI
-
-### Endpoints
-- `/facturador/recibo`: Endpoint para el procesamiento de recibos
-- `/facturador/recibo/pendientes`: Endpoint para consultar recibos pendientes
-- `/actuator`: Endpoints de monitoreo y métricas
-- `/v3/api-docs`: Documentación OpenAPI
-- `/swagger-ui.html`: Interfaz de Swagger UI
-
-### Dependencias Principales
-- Spring Boot 4.0.5
-- Spring Cloud 2025.1.0
-- Spring WebFlux
-- Spring Cloud OpenFeign
-- Spring Boot Actuator
-- Spring Boot Validation
-- Spring Boot Cache
-- Caffeine Cache
-- SpringDoc OpenAPI 3.0.2
-- Lombok

--- a/docs/diagrams/flujo-facturacion.mmd
+++ b/docs/diagrams/flujo-facturacion.mmd
@@ -6,13 +6,13 @@ sequenceDiagram
     participant FEC as FacturacionElectronicaClient
     participant FAC as FacturacionAfipClient
 
-    C->>+FC: POST /facturar (datos)
-    FC->>+FS: facturar(datos)
+    C->>+FC: GET /api/tesoreria/facturador/facturaOne/{chequeraPagoId}
+    FC->>+FS: findOne(chequeraPagoId)
     FS->>+CCC: getByChequeraCuotaId(...)
     CCC-->>-FS: Retorna ChequeraCuotaDto
-    FS->>+FEC: getByChequeraId(...)
+    FS->>+FEC: getByChequeraPagoId(...)
     FEC-->>-FS: Retorna FacturacionElectronicaDto
     FS->>+FAC: generarComprobante(factura)
     FAC-->>-FS: Retorna ComprobanteAfipDto (con CAE)
-    FS-->>-FC: Retorna Comprobante
-    FC-->>-C: Retorna 200 OK (Comprobante)
+    FS-->>-FC: Retorna comprobante procesado
+    FC-->>-C: Retorna 200 OK (respuesta)

--- a/pom.xml
+++ b/pom.xml
@@ -5,18 +5,18 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.5</version>
+		<version>4.1.0</version>
 		<relativePath/>
 		<!-- lookup parent from repository -->
 	</parent>
 	<groupId>ar.edu</groupId>
 	<artifactId>um.facturador-service</artifactId>
-	<version>0.4.0</version>
+	<version>0.4.1</version>
 	<name>UM.tesoreria.facturador-service</name>
 	<description>Spring Boot Microservice Facturador</description>
 	<properties>
 		<java.version>25</java.version>
-		<spring-cloud.version>2025.1.0</spring-cloud.version>
+		<spring-cloud.version>2025.1.2</spring-cloud.version>
 		<sonar.organization>um-services</sonar.organization>
 		<sonar.projectKey>UM-services_UM.tesoreria.facturador-service</sonar.projectKey>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>3.0.2</version>
+			<version>3.0.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
Closes #74

## Descripción

Actualización de dependencias principales y documentación para la versión **0.4.1** del microservicio `um.facturador-service`.

## Cambios Realizados

### Dependencias (pom.xml)

| Dependencia | Anterior | Nueva |
|---|---|---|
| Spring Boot parent | `4.0.5` | `4.1.0` |
| Spring Cloud | `2025.1.0` | `2025.1.2` |
| springdoc-openapi-starter-webmvc-ui | `3.0.2` | `3.0.3` |
| Versión del artefacto | `0.4.0` | `0.4.1` |

### Documentación

- **CHANGELOG.md**: Agregada entrada para v0.4.1 (2026-06-16).
- **README.md**: Shields de versiones actualizados, paths de API corregidos (prefijo `/api/tesoreria/facturador/`), referencia de Eureka a Consul, secciones obsoletas eliminadas.
- **docs/diagrams/flujo-facturacion.mmd**: Diagrama de secuencia actualizado con los nuevos paths.

### Archivos modificados

- `pom.xml` — bump de versiones
- `CHANGELOG.md` — entrada v0.4.1
- `README.md` — docs y shields actualizados
- `docs/diagrams/flujo-facturacion.mmd` — diagrama actualizado

## Verificación

- [ ] `mvn clean compile` sin errores
- [ ] `mvn test` pasa correctamente
- [ ] Revisar que los shields en README reflejen las versiones correctas
- [ ] Verificar compatibilidad Spring Boot 4.1.0 con dependencias existentes
