### PR TITLE
feat(config): configurar timeouts OpenFeign y actualizar diagrama de despliegue v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es-ES/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.4] - 2026-07-27
+
+### Changed
+- chore(config): Configuración de timeouts de OpenFeign en `bootstrap.yml`. Se establece `connectTimeout` en 15 segundos y `readTimeout` en 300 segundos (5 minutos) para mejorar la resiliencia en comunicaciones síncronas con servicios externos.
+
+### Fuente
+- Basado en análisis de cambios staged (`git diff HEAD`) en `src/main/resources/bootstrap.yml`.
+
 ## [0.4.3] - 2026-07-10
 
 ### Changed

--- a/docs/diagrams/despliegue.mmd
+++ b/docs/diagrams/despliegue.mmd
@@ -1,15 +1,11 @@
 graph TD
-    subgraph "Entorno de Despliegue (e.g., Servidor Linux)"
-        subgraph "Docker"
-            container("
-                <b>Contenedor: facturador-service</b><br/>
-                Aplicación Spring Boot<br/>
-                Puerto Expuesto: 8080
-            ")
+    subgraph Entorno["Entorno de Despliegue (Servidor Linux)"]
+        subgraph Docker["Docker"]
+            container[("<b>Contenedor: facturador-service</b><br/>Aplicación Spring Boot<br/>Puerto Expuesto: 8080")]
         end
     end
 
-    subgraph "Red Externa"
+    subgraph RedExterna["Red Externa"]
         lb[("Load Balancer / Gateway")]
     end
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>ar.edu</groupId>
 	<artifactId>um.facturador-service</artifactId>
-	<version>0.4.2</version>
+	<version>0.4.4</version>
 	<name>UM.tesoreria.facturador-service</name>
 	<description>Spring Boot Microservice Facturador</description>
 	<properties>

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -13,6 +13,12 @@ spring:
   application:
     name: tesoreria-facturador-service
   cloud:
+    openfeign:
+      client:
+        config:
+          default:
+            connectTimeout: 15000
+            readTimeout: 300000
     consul:
       host: ${app.consul.host}
       port: ${app.consul.port}


### PR DESCRIPTION
Closes #80

## Descripción

Configuración de timeouts de OpenFeign en `bootstrap.yml` para mejorar la resiliencia en comunicaciones síncronas con servicios externos, junto con mejoras en la sintaxis del diagrama de despliegue Mermaid y actualización de versión a `0.4.4`.

## Cambios Realizados

- [x] Configuración de `connectTimeout` (15s) y `readTimeout` (300s) para OpenFeign en `bootstrap.yml`
- [x] Corrección de sintaxis Mermaid v10+ en diagrama de despliegue (`docs/diagrams/despliegue.mmd`)
- [x] Bump de versión `0.4.2` → `0.4.4` en `pom.xml`
- [x] Entrada en `CHANGELOG.md` para versión `[0.4.4]`

## Verificación

- Verificar que la compilación del proyecto es exitosa (`mvn compile`)
- Verificar que el diagrama Mermaid renderiza correctamente en GitHub
- Validar que las comunicaciones síncronas con servicios externos funcionan bajo los nuevos timeouts configurados
